### PR TITLE
Adding support for latest Trello

### DIFF
--- a/Chromium/manifest.json
+++ b/Chromium/manifest.json
@@ -1,16 +1,20 @@
 {
-  "manifest_version": 2,
-
+  "manifest_version": 3,
   "name": "Trello Clean",
   "description": "Get a clean board on Trello.com",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Manuel Gruber",
   "homepage_url": "http://manuelgruber.com/trello-clean",
   "content_scripts": [
     {
-      "matches": ["https://trello.com/*"],
-      "css": ["/trello-clean.css"],
+      "matches": [
+        "https://trello.com/*"
+      ],
+      "css": [
+        "/trello-clean.css"
+      ],
       "run_at": "document_end"
     }
-  ]
+  ],
+  "content_security_policy": {}
 }

--- a/Chromium/trello-clean.css
+++ b/Chromium/trello-clean.css
@@ -1,3 +1,6 @@
 .js-add-list.list-wrapper.mod-add.is-idle {
   display: none;
 }
+button[data-testid="list-composer-button"] {
+  display: none;
+}


### PR DESCRIPTION
Trello has been rolling out a new version for some months, rendering this extension non-functional. This adds support for latest version.